### PR TITLE
Update for mobile devices

### DIFF
--- a/js/adapt-submitAll.js
+++ b/js/adapt-submitAll.js
@@ -80,7 +80,7 @@ define([
 		removeEventListeners: function() {
 			this.model.get('_componentViews').forEach(function(view) {
 				if (view.model.get('_component') === 'textinput') {
-					view.$el.find('input').off('change.submitAll');
+					view.$el.find('input').off('input.submitAll change.submitAll');
 					return;
 				}
 				view.$el.off('click.submitAll');
@@ -102,7 +102,7 @@ define([
 			if (parentArticleId === submitAllArticleId) {
 				this.model.get('_componentViews').push(view);
 				if (view.model.get('_component') === 'textinput') {
-					view.$el.find('input').on('change.submitAll', this.onInteraction);
+					view.$el.find('input').on('input.submitAll change.submitAll', this.onInteraction);
 					return;
 				}
 				view.$el.on('click.submitAll', this.onInteraction);


### PR DESCRIPTION
These changes are good, but I did notice that on mobile devices you have to dismiss the keyboard in order to enable the submit button. With this change the submit button will be enabled when the user has entered data; even if the text field is still the first responder