### PR TITLE
Fix issue with submit button not appearing on Safari 14.1.1

### DIFF
--- a/js/adapt-submitAll.js
+++ b/js/adapt-submitAll.js
@@ -52,7 +52,7 @@ define([
         if ($div.length > 0) return $div;
       }
 
-      return $article.find('.block').last();
+      return $article;
     },
 
     enableSubmitAllButton: function(enable) {


### PR DESCRIPTION
The submit button is not appearing on Safari 14.1.1 (macOS 11.4). After investigating the problem, I discovered that the button was not appended after the last container inside the article on Safari 14.1.1 because the blocks were not rendered during the append-time ($article.find('.block').length was 0), while it worked on other browsers.

To fix this issue, I have updated the code to append the submit button after the article instead of after the last container inside the article. This quick fix should ensure that the submit button appears on Safari 14.1.1 as expected.