### PR TITLE
New: Added configurable button text (fixes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,27 @@ The extension will hide the 'buttons' `<div>` for all the questions within the a
 
 The following attributes are set within *articles.json*.
 
-### **_submitAll** (object)
+### **\_submitAll** (object)
 
 The Submit All object. It contains the following settings:
 
-#### **_isEnabled** (boolean)
+#### **\_isEnabled** (boolean)
 
 Turns on and off the extension.
 
-#### **_insertAfterBlock** (string)
+#### **\_insertAfterBlock** (string)
 
 If you want the submit button to be appended to a specific block within this article, insert the block ID here. Leave blank to default to the last block in the article.
+
+#### **\_button** (object)
+
+##### **buttonText** (string)
+
+Sets the text that appears for the visual submit all button.
+
+##### **ariaLabel** (string)
+
+Defines the text for the submit all button that is read out by screen readers.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ If you want the submit button to be appended to a specific block within this art
 
 ##### **buttonText** (string)
 
-Sets the text that appears for the visual submit all button.
+Sets the text that appears for the visual submit all button. The default value is `Submit all`.
 
 ##### **ariaLabel** (string)
 
-Defines the text for the submit all button that is read out by screen readers.
+Defines the text for the submit all button that is read out by screen readers. The default value is `Submit all`.
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Defines the text for the submit all button that is read out by screen readers. T
 - Since the standard button group for each question gets hidden, the user will have no way of accessing the 'correct answer' functionality.
 
 ----------------------------
-**Author / maintainer:** CGKineo<br>
+**Author / maintainer:** Kineo<br>
 **AAT support:** No<br>
 **Accessibility support:** WAI AA<br>
 **RTL support:** Yes<br>

--- a/example.json
+++ b/example.json
@@ -3,7 +3,7 @@
         "_isEnabled": true,
         "_insertAfterBlock": "",
         "_button": {
-            "buttonText": "Save and Continue",
-            "ariaLabel": "Save and Continue"
+            "buttonText": "Submit all",
+            "ariaLabel": "Submit all"
         }
     }

--- a/example.json
+++ b/example.json
@@ -1,5 +1,9 @@
     // To go in articles.json
     "_submitAll": {
         "_isEnabled": true,
-        "_insertAfterBlock": ""
+        "_insertAfterBlock": "",
+        "_button": {
+            "buttonText": "Save and Continue",
+            "ariaLabel": "Save and Continue"
+        }
     }

--- a/js/SubmitAllView.js
+++ b/js/SubmitAllView.js
@@ -25,7 +25,7 @@ export default class SubmitAllView extends Backbone.View {
     const {
       buttonText,
       ariaLabel
-    } = Adapt.course.get('_buttons')._submit;
+    } = this.model.get('_button');
     const data = {
       ...this,
       model: this.model.toJSON(),

--- a/js/SubmitAllView.js
+++ b/js/SubmitAllView.js
@@ -22,10 +22,10 @@ export default class SubmitAllView extends Backbone.View {
 
   render() {
     this.articleView.$el.addClass('no-submit-buttons');
-    const {
-      buttonText,
-      ariaLabel
-    } = this.model.get('_button');
+    const buttons = this.model.get('_button');
+    const courseSubmitButtons = Adapt.course.get('_buttons')._submit;
+    const buttonText = buttons.buttonText || courseSubmitButtons.buttonText;
+    const ariaLabel = buttons.ariaLabel || courseSubmitButtons.ariaLabel;
     const data = {
       ...this,
       model: this.model.toJSON(),

--- a/js/SubmitAllView.js
+++ b/js/SubmitAllView.js
@@ -25,7 +25,7 @@ export default class SubmitAllView extends Backbone.View {
     const buttons = this.model.get('_button');
     const courseSubmitButtons = Adapt.course.get('_buttons')._submit;
     const buttonText = buttons?.buttonText ?? courseSubmitButtons.buttonText;
-    const ariaLabel = buttons.ariaLabel || courseSubmitButtons.ariaLabel;
+    const ariaLabel = buttons?.ariaLabel ?? courseSubmitButtons.ariaLabel;
     const data = {
       ...this,
       model: this.model.toJSON(),

--- a/js/SubmitAllView.js
+++ b/js/SubmitAllView.js
@@ -24,7 +24,7 @@ export default class SubmitAllView extends Backbone.View {
     this.articleView.$el.addClass('no-submit-buttons');
     const buttons = this.model.get('_button');
     const courseSubmitButtons = Adapt.course.get('_buttons')._submit;
-    const buttonText = buttons.buttonText || courseSubmitButtons.buttonText;
+    const buttonText = buttons?.buttonText ?? courseSubmitButtons.buttonText;
     const ariaLabel = buttons.ariaLabel || courseSubmitButtons.ariaLabel;
     const data = {
       ...this,

--- a/properties.schema
+++ b/properties.schema
@@ -49,7 +49,7 @@
                     "buttonText": {
                       "type": "string",
                       "title": "Button text",
-                      "default": "Save and Continue",
+                      "default": "Submit all",
                       "inputType": "Text",
                       "required": false,
                       "validators": [],
@@ -58,7 +58,7 @@
                     "ariaLabel": {
                       "type": "string",
                       "title": "ARIA label",
-                      "default": "Save and Continue",
+                      "default": "Submit all",
                       "inputType": "Text",
                       "required": false,
                       "validators": [],

--- a/properties.schema
+++ b/properties.schema
@@ -40,6 +40,31 @@
                   "inputType": "Text",
                   "validators": [],
                   "help": "If you want the submit button to be appended to a specific block within this article, insert its ID here. Leave blank to default to the last block in the article."
+                },
+                "_button": {
+                  "type": "object",
+                  "required": false,
+                  "legend": "Button",
+                  "properties": {
+                    "buttonText": {
+                      "type": "string",
+                      "title": "Button text",
+                      "default": "Save and Continue",
+                      "inputType": "Text",
+                      "required": false,
+                      "validators": [],
+                      "translatable": true
+                    },
+                    "ariaLabel": {
+                      "type": "string",
+                      "title": "ARIA label",
+                      "default": "Save and Continue",
+                      "inputType": "Text",
+                      "required": false,
+                      "validators": [],
+                      "translatable": true
+                    }
+                  }
                 }
               }
             }

--- a/templates/submitAll.jsx
+++ b/templates/submitAll.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { classes } from 'core/js/reactHelpers';
+import { classes, compile } from 'core/js/reactHelpers';
 
 export default function SubmitAll (props) {
   const {
@@ -9,8 +9,9 @@ export default function SubmitAll (props) {
   } = props;
 
   return (
-    <div className={'btn__container'}>
-      <div className={'btn__response-container'}>
+    <div className='btn__container'>
+      <div className='btn__response-container'>
+
         <button
           className={classes([
             'btn-text',
@@ -19,11 +20,11 @@ export default function SubmitAll (props) {
             'is-disabled'
           ])}
           aria-label={ariaLabel}
-          aria-disabled="true"
+          aria-disabled='true'
           onClick={onSubmitAllButtonClicked}
-        >
-          {buttonText}
-        </button>
+          dangerouslySetInnerHTML={{ __html: compile(buttonText) }}
+        />
+
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes: #11 

### New
* Added a new config options `buttonText` and `ariaLabel` to allow for custom button text 

e.g.
```
"_button": {
  "buttonText": "Submit all",
  "ariaLabel": "Submit all"
}
```
